### PR TITLE
Bdog 1215a

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ libraryDependencies += "uk.gov.hmrc" %% "bootstrap-backend-play-26" % "x.x.x"
 In your application.conf file, add:
 
 ```properties
+include "frontend.conf"
+
 # An ApplicationLoader that uses Guice to bootstrap the application.
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 
@@ -57,6 +59,8 @@ libraryDependencies += "uk.gov.hmrc" %% "govuk-template" % "x.x.x"
 In your application.conf file, add:
 
 ```properties
+include "backend.conf"
+
 # An ApplicationLoader that uses Guice to bootstrap the application.
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 

--- a/bootstrap-backend-play-26/src/main/resources/backend.conf
+++ b/bootstrap-backend-play-26/src/main/resources/backend.conf
@@ -1,4 +1,4 @@
-# Copyright 2020 HM Revenue & Customs
+# Copyright 2021 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/BackendModule.scala
+++ b/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/BackendModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/controller/BackendController.scala
+++ b/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/controller/BackendController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/filters/BackendAuditFilter.scala
+++ b/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/filters/BackendAuditFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/filters/BackendAuditFilter.scala
+++ b/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/filters/BackendAuditFilter.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.play.bootstrap.backend.filters
 
 import akka.stream.Materializer
 import javax.inject.Inject
+import play.api.Configuration
 import play.api.mvc.{RequestHeader, ResponseHeader, Result}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
@@ -43,12 +44,16 @@ trait BackendAuditFilter
 }
 
 class DefaultBackendAuditFilter @Inject()(
+  config: Configuration,
   controllerConfigs: ControllerConfigs,
   override val auditConnector: AuditConnector,
   httpAuditEvent: HttpAuditEvent,
   override val mat: Materializer
 )(implicit protected val ec: ExecutionContext
 ) extends BackendAuditFilter {
+
+  override val isAuditingEnabled: Boolean =
+    config.get[Boolean]("auditing.enabled")
 
   override def controllerNeedsAuditing(controllerName: String): Boolean =
     controllerConfigs.controllerNeedsAuditing(controllerName)

--- a/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/filters/BackendAuditFilter.scala
+++ b/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/filters/BackendAuditFilter.scala
@@ -16,151 +16,30 @@
 
 package uk.gov.hmrc.play.bootstrap.backend.filters
 
-import akka.stream._
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
-import akka.util.ByteString
+import akka.stream.Materializer
 import javax.inject.Inject
-import play.api.Logger
-import play.api.http.HttpEntity
-import play.api.http.HttpEntity.Streamed
-import play.api.libs.streams.Accumulator
-import play.api.mvc.{Result, _}
-import play.api.routing.Router.Attrs
+import play.api.mvc.{RequestHeader, ResponseHeader, Result}
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.audit.EventKeys._
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.model.DataEvent
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendHeaderCarrierProvider
 import uk.gov.hmrc.play.bootstrap.config.{ControllerConfigs, HttpAuditEvent}
-import uk.gov.hmrc.play.bootstrap.filters.{AuditFilter, RequestBodyCaptor, ResponseBodyCaptor}
-import uk.gov.hmrc.play.http.HeaderCarrierConverter
+import uk.gov.hmrc.play.bootstrap.filters.CommonAuditFilter
 
-import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.ExecutionContext
 
-trait BackendAuditFilter extends AuditFilter {
+trait BackendAuditFilter
+  extends CommonAuditFilter
+     with BackendHeaderCarrierProvider {
 
-  private val logger = Logger(getClass)
+  override protected def filterResponseBody(result: Result, response: ResponseHeader, responseBody: String): String =
+    responseBody
 
-  protected implicit def ec: ExecutionContext
-  def auditConnector: AuditConnector
+  override protected def buildRequestDetails(requestHeader: RequestHeader, request: String): Map[String, String] =
+    Map.empty
 
-  def controllerNeedsAuditing(controllerName: String): Boolean
-
-  def dataEvent(
-    eventType: String,
-    transactionName: String,
-    request: RequestHeader,
-    detail: Map[String, String] = Map()
-  )(implicit
-    hc: HeaderCarrier
-  ): DataEvent
-
-  implicit def mat: Materializer
-
-  val maxBodySize = 32665
-
-  val requestReceived = "RequestReceived"
-
-  def apply(nextFilter: EssentialAction) = new EssentialAction {
-    def apply(requestHeader: RequestHeader) = {
-      val next: Accumulator[ByteString, Result] = nextFilter(requestHeader)
-
-      implicit val hc = HeaderCarrierConverter.fromRequest(requestHeader)
-
-      val loggingContext = s"${requestHeader.method} ${requestHeader.uri}"
-
-      def performAudit(requestBody: String, tryResult: Try[Result])(responseBody: String): Unit = {
-        val detail = tryResult match {
-          case Success(result) =>
-            Map(
-              ResponseMessage -> responseBody,
-              StatusCode -> result.header.status.toString
-            )
-          case Failure(f) =>
-            Map(FailedRequestMessage -> f.getMessage)
-        }
-        auditConnector.sendEvent(
-          dataEvent(
-            eventType       = requestReceived,
-            transactionName = requestHeader.uri,
-            request         = requestHeader,
-            detail          = detail
-          )
-        )
-      }
-
-      if (needsAuditing(requestHeader)) {
-        onCompleteWithInput(loggingContext, next, performAudit)
-      } else next
-    }
-  }
-
-  protected def needsAuditing(request: RequestHeader): Boolean =
-    request.attrs.get(Attrs.HandlerDef).forall { handlerDef =>
-      controllerNeedsAuditing(handlerDef.controller)
-    }
-
-  protected def onCompleteWithInput(
-    loggingContext: String,
-    next: Accumulator[ByteString, Result],
-    handler: (String, Try[Result]) => String => Unit)(
-    implicit ec: ExecutionContext): Accumulator[ByteString, Result] = {
-    val requestBodyPromise = Promise[String]()
-    val requestBodyFuture  = requestBodyPromise.future
-
-    var requestBody: String = ""
-    def callback(body: ByteString): Unit = {
-      requestBody = body.decodeString("UTF-8")
-      requestBodyPromise success requestBody
-    }
-
-    //grabbed from plays csrf filter
-    val wrappedAcc: Accumulator[ByteString, Result] = Accumulator(
-      Flow[ByteString]
-        .via(new RequestBodyCaptor(loggingContext, maxBodySize, callback))
-        .splitWhen(_ => false)
-        .prefixAndTail(0)
-        .map(_._2)
-        .concatSubstreams
-        .toMat(Sink.head[Source[ByteString, _]])(Keep.right)
-    ).mapFuture { bodySource =>
-      next.run(bodySource)
-    }
-
-    wrappedAcc
-      .mapFuture { result =>
-        requestBodyFuture flatMap { res =>
-          {
-            val auditedBody = result.body match {
-              case str: Streamed => {
-                val auditFlow = Flow[ByteString].alsoTo(
-                  new ResponseBodyCaptor(loggingContext, maxBodySize, handler(requestBody, Success(result))))
-                str.copy(data = str.data.via(auditFlow))
-              }
-              case h: HttpEntity => {
-                h.consumeData map { rb =>
-                  val auditString = if (rb.size > maxBodySize) {
-                    logger.warn(
-                      s"txm play auditing: $loggingContext response body ${rb.size} exceeds maxLength $maxBodySize - do you need to be auditing this payload?")
-                    rb.take(maxBodySize).decodeString("UTF-8")
-                  } else {
-                    rb.decodeString("UTF-8")
-                  }
-                  handler(res, Success(result))(auditString)
-                }
-                h
-              }
-            }
-            Future(result.copy(body = auditedBody))
-          }
-        }
-      }
-      .recover[Result] {
-        case ex: Throwable =>
-          handler(requestBody, Failure(ex))("")
-          throw ex
-      }
-  }
+  override protected def buildResponseDetails(response: ResponseHeader): Map[String, String] =
+    Map.empty
 }
 
 class DefaultBackendAuditFilter @Inject()(
@@ -168,16 +47,17 @@ class DefaultBackendAuditFilter @Inject()(
   override val auditConnector: AuditConnector,
   httpAuditEvent: HttpAuditEvent,
   override val mat: Materializer
-)(implicit protected val ec: ExecutionContext) extends BackendAuditFilter {
+)(implicit protected val ec: ExecutionContext
+) extends BackendAuditFilter {
 
   override def controllerNeedsAuditing(controllerName: String): Boolean =
     controllerConfigs.controllerNeedsAuditing(controllerName)
 
   override def dataEvent(
-    eventType: String,
+    eventType      : String,
     transactionName: String,
-    request: RequestHeader,
-    detail: Map[String, String]
+    request        : RequestHeader,
+    detail         : Map[String, String]
   )(implicit hc: HeaderCarrier): DataEvent =
     httpAuditEvent.dataEvent(eventType, transactionName, request, detail)
 }

--- a/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/filters/BackendAuditFilter.scala
+++ b/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/filters/BackendAuditFilter.scala
@@ -44,16 +44,13 @@ trait BackendAuditFilter
 }
 
 class DefaultBackendAuditFilter @Inject()(
-  config: Configuration,
+  override val config: Configuration,
   controllerConfigs: ControllerConfigs,
   override val auditConnector: AuditConnector,
   httpAuditEvent: HttpAuditEvent,
   override val mat: Materializer
 )(implicit protected val ec: ExecutionContext
 ) extends BackendAuditFilter {
-
-  override val isAuditingEnabled: Boolean =
-    config.get[Boolean]("auditing.enabled")
 
   override def controllerNeedsAuditing(controllerName: String): Boolean =
     controllerConfigs.controllerNeedsAuditing(controllerName)

--- a/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/filters/BackendFilters.scala
+++ b/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/filters/BackendFilters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/http/ErrorResponse.scala
+++ b/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/http/ErrorResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/http/JsonErrorHandler.scala
+++ b/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/http/JsonErrorHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/package.scala
+++ b/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/package.scala
+++ b/bootstrap-backend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/package.scala
@@ -66,12 +66,14 @@ package bootstrap {
     package microservice {
       @deprecated("Use uk.gov.hmrc.play.bootstrap.backend.filters.DefaultBackendAuditFilter instead", "2.12.0")
       class DefaultMicroserviceAuditFilter @Inject()(
+        config           : Configuration,
         controllerConfigs: ControllerConfigs,
         auditConnector   : AuditConnector,
         httpAuditEvent   : HttpAuditEvent,
         mat              : Materializer
       )(implicit ec: ExecutionContext
       ) extends uk.gov.hmrc.play.bootstrap.backend.filters.DefaultBackendAuditFilter(
+        config,
         controllerConfigs,
         auditConnector,
         httpAuditEvent,

--- a/bootstrap-backend-play-26/src/test/resources/backend.test.conf
+++ b/bootstrap-backend-play-26/src/test/resources/backend.test.conf
@@ -1,4 +1,4 @@
-# Copyright 2020 HM Revenue & Customs
+# Copyright 2021 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/BackendConfigLoadSpec.scala
+++ b/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/BackendConfigLoadSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/BackwardCompatibilitySpec.scala
+++ b/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/BackwardCompatibilitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/BackwardCompatibilitySpec.scala
+++ b/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/BackwardCompatibilitySpec.scala
@@ -80,6 +80,7 @@ class BackwardCompatibilitySpec
         override def ec             = mock[ExecutionContext]
         override def auditConnector = mock[uk.gov.hmrc.play.audit.http.connector.AuditConnector]
         override def mat            = mock[Materializer]
+        override val isAuditingEnabled: Boolean = true
         override def controllerNeedsAuditing(controllerName: String): Boolean = true
         override def dataEvent(
           eventType      : String,
@@ -92,6 +93,7 @@ class BackwardCompatibilitySpec
 
     "preserve uk.gov.hmrc.play.bootstrap.filters.microservice.DefaultMicroserviceAuditFilter" in {
       new uk.gov.hmrc.play.bootstrap.filters.microservice.DefaultMicroserviceAuditFilter(
+        config            = mock[Configuration],
         controllerConfigs = mock[uk.gov.hmrc.play.bootstrap.config.ControllerConfigs],
         auditConnector    = mock[uk.gov.hmrc.play.audit.http.connector.AuditConnector],
         httpAuditEvent    = mock[uk.gov.hmrc.play.bootstrap.config.HttpAuditEvent],

--- a/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/BackwardCompatibilitySpec.scala
+++ b/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/BackwardCompatibilitySpec.scala
@@ -78,9 +78,9 @@ class BackwardCompatibilitySpec
     "preserve uk.gov.hmrc.play.bootstrap.filters.microservice.MicroserviceAuditFilter" in {
       new uk.gov.hmrc.play.bootstrap.filters.microservice.MicroserviceAuditFilter {
         override def ec             = mock[ExecutionContext]
+        override def config         = mock[Configuration]
         override def auditConnector = mock[uk.gov.hmrc.play.audit.http.connector.AuditConnector]
         override def mat            = mock[Materializer]
-        override val isAuditingEnabled: Boolean = true
         override def controllerNeedsAuditing(controllerName: String): Boolean = true
         override def dataEvent(
           eventType      : String,

--- a/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/controller/BackendHeaderCarrierProviderSpec.scala
+++ b/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/controller/BackendHeaderCarrierProviderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/filters/BackendAuditFilterSpec.scala
+++ b/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/filters/BackendAuditFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/filters/BackendAuditFilterSpec.scala
+++ b/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/filters/BackendAuditFilterSpec.scala
@@ -26,6 +26,7 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.Configuration
 import play.api.mvc.Results.NotFound
 import play.api.mvc.{Action, AnyContent}
 import play.api.test.FakeRequest
@@ -75,12 +76,13 @@ class BackendAuditFilterSpec
 
     val httpAuditEvent = new HttpAuditEvent { override def appName = applicationName }
 
-    def createAuditFilter(connector: AuditConnector) =
-      new DefaultBackendAuditFilter(controllerConfigs, connector, httpAuditEvent, materializer)
+    def createAuditFilter(config: Configuration, connector: AuditConnector) =
+      new DefaultBackendAuditFilter(config, controllerConfigs, connector, httpAuditEvent, materializer)
 
     "audit a request and response with header information" in {
       val mockAuditConnector = mock[AuditConnector]
-      val auditFilter        = createAuditFilter(mockAuditConnector)
+      val config             = Configuration("auditing.enabled" -> true)
+      val auditFilter        = createAuditFilter(config, mockAuditConnector)
 
       when(mockAuditConnector.sendEvent(any[DataEvent])(any[HeaderCarrier], any[ExecutionContext]))
         .thenReturn(Future.successful(Success))
@@ -105,9 +107,27 @@ class BackendAuditFilterSpec
       }
     }
 
+    "skip auditing when disabled" in {
+      val mockAuditConnector = mock[AuditConnector]
+      val config             = Configuration("auditing.enabled" -> false)
+      val auditFilter        = createAuditFilter(config, mockAuditConnector)
+
+      when(mockAuditConnector.sendEvent(any[DataEvent])(any[HeaderCarrier], any[ExecutionContext]))
+        .thenReturn(Future.successful(Success))
+
+      val result = await(auditFilter.apply(nextAction)(request).run)
+
+      await(result.body.dataStream.runForeach { i => })
+
+      eventually {
+        verifyNoMoreInteractions(mockAuditConnector)
+      }
+    }
+
     "audit a response even when an action further down the chain throws an exception" in {
       val mockAuditConnector = mock[AuditConnector]
-      val auditFilter        = createAuditFilter(mockAuditConnector)
+      val config             = Configuration("auditing.enabled" -> true)
+      val auditFilter        = createAuditFilter(config, mockAuditConnector)
 
       when(mockAuditConnector.sendEvent(any[DataEvent])(any[HeaderCarrier], any[ExecutionContext]))
         .thenReturn(Future.successful(Success))

--- a/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/http/JsonErrorHandlerSpec.scala
+++ b/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/http/JsonErrorHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/logging/MDCBackendLoggingSpec.scala
+++ b/bootstrap-backend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/backend/logging/MDCBackendLoggingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/resources/reference.conf
+++ b/bootstrap-common-play-26/src/main/resources/reference.conf
@@ -1,0 +1,15 @@
+# Copyright 2021 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+auditing.enabled = true

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/ApplicationLoader.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/ApplicationLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/AuditModule.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/AuditModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/AuthModule.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/AuthModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/BootstrapModule.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/BootstrapModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/HttpClientModule.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/HttpClientModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/audit/DefaultAuditConnector.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/audit/DefaultAuditConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/auth/DefaultAuthConnector.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/auth/DefaultAuthConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/binders/RedirectUrl.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/binders/RedirectUrl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AppName.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AppName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AuditingConfigProvider.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AuditingConfigProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AuditingConfigProvider.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AuditingConfigProvider.scala
@@ -26,42 +26,38 @@ class AuditingConfigProvider @Inject()(
 ) extends Provider[AuditingConfig] {
 
   def get(): AuditingConfig = {
-    configuration
-      .getOptional[Configuration]("auditing")
-      .map { c =>
-        val enabled = c.getOptional[Boolean]("enabled").getOrElse(true)
+    val c = configuration.get[Configuration]("auditing")
+    val enabled = c.get[Boolean]("enabled")
 
-        if (enabled) {
-          AuditingConfig(
-            enabled = enabled,
-            consumer = Some(
-              c.getOptional[Configuration]("consumer")
-                .map { con =>
-                  Consumer(
-                    baseUri = con
-                      .getOptional[Configuration]("baseUri")
-                      .map { uri =>
-                        BaseUri(
-                          host = uri
-                            .getOptional[String]("host")
-                            .getOrElse(throw new Exception("Missing consumer host for auditing")),
-                          port = uri
-                            .getOptional[Int]("port")
-                            .getOrElse(throw new Exception("Missing consumer port for auditing")),
-                          protocol = uri.getOptional[String]("protocol").getOrElse("http")
-                        )
-                      }
-                      .getOrElse(throw new Exception("Missing consumer baseUri for auditing"))
-                  )
-                }
-                .getOrElse(throw new Exception("Missing consumer configuration for auditing"))
-            ),
-            auditSource = appName,
-            auditExtraHeaders = c.getOptional[Boolean]("auditExtraHeaders")
-          )
-        } else {
-          AuditingConfig(consumer = None, enabled = false, auditSource = "auditing disabled")
-        }
-      }
-  }.getOrElse(throw new Exception("Missing auditing configuration"))
+    if (enabled) {
+      AuditingConfig(
+        enabled = enabled,
+        consumer = Some(
+          c.getOptional[Configuration]("consumer")
+            .map { con =>
+              Consumer(
+                baseUri = con
+                  .getOptional[Configuration]("baseUri")
+                  .map { uri =>
+                    BaseUri(
+                      host = uri
+                        .getOptional[String]("host")
+                        .getOrElse(throw new Exception("Missing consumer host for auditing")),
+                      port = uri
+                        .getOptional[Int]("port")
+                        .getOrElse(throw new Exception("Missing consumer port for auditing")),
+                      protocol = uri.getOptional[String]("protocol").getOrElse("http")
+                    )
+                  }
+                  .getOrElse(throw new Exception("Missing consumer baseUri for auditing"))
+              )
+            }
+            .getOrElse(throw new Exception("Missing consumer configuration for auditing"))
+        ),
+        auditSource = appName,
+        auditExtraHeaders = c.getOptional[Boolean]("auditExtraHeaders")
+      )
+    } else
+      AuditingConfig(consumer = None, enabled = false, auditSource = "auditing disabled")
+  }
 }

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AuditingConfigProvider.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AuditingConfigProvider.scala
@@ -30,34 +30,26 @@ class AuditingConfigProvider @Inject()(
     val enabled = c.get[Boolean]("enabled")
 
     if (enabled) {
+      val con = getRequired[Configuration](c, "consumer", "Missing consumer configuration `auditing.consumer` for auditing")
+      val uri = getRequired[Configuration](con, "baseUri", "Missing consumer baseUri `auditing.consumer.baseUri` for auditing")
       AuditingConfig(
-        enabled = enabled,
-        consumer = Some(
-          c.getOptional[Configuration]("consumer")
-            .map { con =>
-              Consumer(
-                baseUri = con
-                  .getOptional[Configuration]("baseUri")
-                  .map { uri =>
-                    BaseUri(
-                      host = uri
-                        .getOptional[String]("host")
-                        .getOrElse(throw new Exception("Missing consumer host for auditing")),
-                      port = uri
-                        .getOptional[Int]("port")
-                        .getOrElse(throw new Exception("Missing consumer port for auditing")),
-                      protocol = uri.getOptional[String]("protocol").getOrElse("http")
-                    )
-                  }
-                  .getOrElse(throw new Exception("Missing consumer baseUri for auditing"))
-              )
-            }
-            .getOrElse(throw new Exception("Missing consumer configuration for auditing"))
-        ),
-        auditSource = appName,
+        enabled           = enabled,
+        consumer          = Some(
+                              Consumer(
+                                BaseUri(
+                                  host     = getRequired[String](uri, "host", "Missing consumer host `auditing.consumer.baseUri.host` for auditing"),
+                                  port     = getRequired[Int](uri, "port", "Missing consumer port `auditing.consumer.baseUri.port` for auditing"),
+                                  protocol = uri.getOptional[String]("protocol").getOrElse("http")
+                                )
+                              )
+                            ),
+        auditSource       = appName,
         auditExtraHeaders = c.getOptional[Boolean]("auditExtraHeaders")
       )
     } else
       AuditingConfig(consumer = None, enabled = false, auditSource = "auditing disabled")
   }
+
+  private def getRequired[T: play.api.ConfigLoader](config: Configuration, key: String, errMsg: => String): T =
+    config.getOptional[T](key).getOrElse(sys.error(errMsg))
 }

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AuthRedirects.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AuthRedirects.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/Base64ConfigDecoder.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/Base64ConfigDecoder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/ControllerConfig.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/ControllerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/CryptoValidation.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/CryptoValidation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/DeprecatedConfigChecker.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/DeprecatedConfigChecker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/HttpAuditEvent.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/HttpAuditEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/ServicesConfig.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/config/ServicesConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/controller/Utf8MimeTypes.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/controller/Utf8MimeTypes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/controller/WithJsonBody.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/controller/WithJsonBody.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/dispatchers/MDCPropagatingExecutorService.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/dispatchers/MDCPropagatingExecutorService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/AuditFilter.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/AuditFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/AuditFilter.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/AuditFilter.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.play.bootstrap.filters
 
+import play.api.Configuration
 import play.api.mvc.EssentialFilter
 import akka.stream._
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
@@ -40,9 +41,9 @@ trait CommonAuditFilter extends AuditFilter {
 
   protected implicit def ec: ExecutionContext
 
-  def auditConnector: AuditConnector
+  def config: Configuration
 
-  def isAuditingEnabled: Boolean
+  def auditConnector: AuditConnector
 
   def controllerNeedsAuditing(controllerName: String): Boolean
 
@@ -102,7 +103,7 @@ trait CommonAuditFilter extends AuditFilter {
   }
 
   protected def needsAuditing(request: RequestHeader): Boolean =
-    isAuditingEnabled &&
+    config.get[Boolean]("auditing.enabled") &&
     request.attrs.get(Attrs.HandlerDef).map(_.controller).forall(controllerNeedsAuditing)
 
   protected def onCompleteWithInput(

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/AuditFilter.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/AuditFilter.scala
@@ -42,6 +42,8 @@ trait CommonAuditFilter extends AuditFilter {
 
   def auditConnector: AuditConnector
 
+  def isAuditingEnabled: Boolean
+
   def controllerNeedsAuditing(controllerName: String): Boolean
 
   def dataEvent(
@@ -100,6 +102,7 @@ trait CommonAuditFilter extends AuditFilter {
   }
 
   protected def needsAuditing(request: RequestHeader): Boolean =
+    isAuditingEnabled &&
     request.attrs.get(Attrs.HandlerDef).map(_.controller).forall(controllerNeedsAuditing)
 
   protected def onCompleteWithInput(

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/AuditFilter.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/AuditFilter.scala
@@ -17,5 +17,151 @@
 package uk.gov.hmrc.play.bootstrap.filters
 
 import play.api.mvc.EssentialFilter
+import akka.stream._
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.util.ByteString
+import play.api.Logger
+import play.api.http.HttpEntity
+import play.api.libs.streams.Accumulator
+import play.api.mvc._
+import play.api.routing.Router.Attrs
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.audit.EventKeys
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+import uk.gov.hmrc.play.audit.model.DataEvent
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Failure, Success, Try}
 
 trait AuditFilter extends EssentialFilter
+
+trait CommonAuditFilter extends AuditFilter {
+  private val logger = Logger(getClass)
+
+  protected implicit def ec: ExecutionContext
+
+  def auditConnector: AuditConnector
+
+  def controllerNeedsAuditing(controllerName: String): Boolean
+
+  def dataEvent(
+    eventType      : String,
+    transactionName: String,
+    request        : RequestHeader,
+    detail         : Map[String, String] = Map()
+  )(implicit
+    hc: HeaderCarrier
+  ): DataEvent
+
+  implicit def mat: Materializer
+
+  val maxBodySize = 32665
+
+  val requestReceived = "RequestReceived"
+
+  implicit protected def hc(implicit request: RequestHeader): HeaderCarrier
+
+  override def apply(nextFilter: EssentialAction) = new EssentialAction {
+    override def apply(requestHeader: RequestHeader): Accumulator[ByteString, Result] = {
+      val next: Accumulator[ByteString, Result] = nextFilter(requestHeader)
+
+      val loggingContext = s"${requestHeader.method} ${requestHeader.uri}"
+
+      def performAudit(requestBody: String, tryResult: Try[Result])(responseBody: String): Unit = {
+        val detail = tryResult match {
+          case Success(result) =>
+            val responseHeader = result.header
+            Map(
+                EventKeys.ResponseMessage -> filterResponseBody(result, responseHeader, responseBody),
+                EventKeys.StatusCode      -> responseHeader.status.toString
+              ) ++
+              buildRequestDetails(requestHeader, requestBody) ++
+              buildResponseDetails(responseHeader)
+          case Failure(f) =>
+            Map(EventKeys.FailedRequestMessage -> f.getMessage) ++
+              buildRequestDetails(requestHeader, requestBody)
+        }
+        implicit val r = requestHeader
+        auditConnector.sendEvent(
+          dataEvent(
+            eventType       = requestReceived,
+            transactionName = requestHeader.uri,
+            request         = requestHeader,
+            detail          = detail
+          )
+        )
+      }
+
+      if (needsAuditing(requestHeader))
+        onCompleteWithInput(loggingContext, next, performAudit)
+      else
+        next
+    }
+  }
+
+  protected def needsAuditing(request: RequestHeader): Boolean =
+    request.attrs.get(Attrs.HandlerDef).map(_.controller).forall(controllerNeedsAuditing)
+
+  protected def onCompleteWithInput(
+    loggingContext: String,
+    next: Accumulator[ByteString, Result],
+    handler: (String, Try[Result]) => String => Unit
+  )(implicit ec: ExecutionContext
+  ): Accumulator[ByteString, Result] = {
+    val requestBodyPromise = Promise[String]()
+    val requestBodyFuture  = requestBodyPromise.future
+
+    var requestBody: String = ""
+    def callback(body: ByteString): Unit = {
+      requestBody = body.decodeString("UTF-8")
+      requestBodyPromise.success(requestBody)
+    }
+
+    //grabbed from plays csrf filter
+    val wrappedAcc: Accumulator[ByteString, Result] = Accumulator(
+      Flow[ByteString]
+        .via(new RequestBodyCaptor(loggingContext, maxBodySize, callback))
+        .splitWhen(_ => false)
+        .prefixAndTail(0)
+        .map(_._2)
+        .concatSubstreams
+        .toMat(Sink.head[Source[ByteString, _]])(Keep.right)
+    ).mapFuture(next.run)
+
+    wrappedAcc
+      .mapFuture { result =>
+        requestBodyFuture.flatMap { res =>
+          val auditedBody = result.body match {
+            case str: HttpEntity.Streamed =>
+              val auditFlow = Flow[ByteString].alsoTo(
+                new ResponseBodyCaptor(loggingContext, maxBodySize, handler(requestBody, Success(result))))
+              str.copy(data = str.data.via(auditFlow))
+            case h: HttpEntity =>
+              h.consumeData.map { rb =>
+                val auditString =
+                  if (rb.size > maxBodySize) {
+                    logger.warn(
+                      s"txm play auditing: $loggingContext response body ${rb.size} exceeds maxLength $maxBodySize - do you need to be auditing this payload?")
+                    rb.take(maxBodySize).decodeString("UTF-8")
+                  } else
+                    rb.decodeString("UTF-8")
+                handler(res, Success(result))(auditString)
+              }
+              h
+          }
+          Future(result.copy(body = auditedBody))
+        }
+      }
+      .recover[Result] {
+        case ex: Throwable =>
+          handler(requestBody, Failure(ex))("")
+          throw ex
+      }
+  }
+
+  protected def filterResponseBody(result: Result, response: ResponseHeader, responseBody: String): String
+
+  protected def buildRequestDetails(requestHeader: RequestHeader, requestBody: String): Map[String, String]
+
+  protected def buildResponseDetails(response: ResponseHeader): Map[String, String]
+}

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/BodyCaptor.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/BodyCaptor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/CacheControlFilter.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/CacheControlFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/LoggingFilter.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/LoggingFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/MDCFilter.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/MDCFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteMetricsModule.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteMetricsModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteProvider.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteReporterProvider.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteReporterProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteReporting.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteReporting.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/http/HttpClient.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/http/HttpClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/http/RequestHandler.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/http/RequestHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/package.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/ApplicationLoaderSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/ApplicationLoaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/binders/RedirectUrlBinderSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/binders/RedirectUrlBinderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/AppNameSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/AppNameSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/AuditingConfigProviderSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/AuditingConfigProviderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/AuthRedirectsSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/AuthRedirectsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/Base64ConfigDecoderSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/Base64ConfigDecoderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/ControllerConfigSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/ControllerConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/DeprecatedConfigCheckerSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/DeprecatedConfigCheckerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/HttpAuditEventSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/HttpAuditEventSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/ServicesConfigSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/config/ServicesConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/controller/Utf8MimeTypesSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/controller/Utf8MimeTypesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/filters/CacheControlFilterSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/filters/CacheControlFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/filters/LoggingFilterSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/filters/LoggingFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteMetricsModuleSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteMetricsModuleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteProviderSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteProviderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteReporterProviderSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteReporterProviderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteReportingSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/graphite/GraphiteReportingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/http/DefaultHttpClientSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/http/DefaultHttpClientSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/http/RequestHandlerSpec.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/http/RequestHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/http/utils/JsonPayloads.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/http/utils/JsonPayloads.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/http/utils/TestAuditConnector.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/http/utils/TestAuditConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/http/utils/WiremockTestServer.scala
+++ b/bootstrap-common-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/http/utils/WiremockTestServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/resources/frontend.conf
+++ b/bootstrap-frontend-play-26/src/main/resources/frontend.conf
@@ -1,4 +1,4 @@
-# Copyright 2020 HM Revenue & Customs
+# Copyright 2021 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/FrontendModule.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/FrontendModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/controller/FrontendController.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/controller/FrontendController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/AllowlistFilter.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/AllowlistFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/FrontendAuditFilter.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/FrontendAuditFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/FrontendAuditFilter.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/FrontendAuditFilter.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.play.bootstrap.frontend.filters
 
 import akka.stream.Materializer
 import javax.inject.Inject
+import play.api.Configuration
 import play.api.http.HeaderNames
 import play.api.mvc.{RequestHeader, ResponseHeader, Result}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -93,6 +94,7 @@ trait FrontendAuditFilter
 }
 
 class DefaultFrontendAuditFilter @Inject()(
+  config: Configuration,
   controllerConfigs: ControllerConfigs,
   override val auditConnector: AuditConnector,
   httpAuditEvent: HttpAuditEvent,
@@ -103,6 +105,9 @@ class DefaultFrontendAuditFilter @Inject()(
   override val maskedFormFields: Seq[String] = Seq.empty
 
   override val applicationPort: Option[Int] = None
+
+  override val isAuditingEnabled: Boolean =
+    config.get[Boolean]("auditing.enabled")
 
   override def controllerNeedsAuditing(controllerName: String): Boolean =
     controllerConfigs.controllerNeedsAuditing(controllerName)

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/FrontendAuditFilter.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/FrontendAuditFilter.scala
@@ -16,207 +16,67 @@
 
 package uk.gov.hmrc.play.bootstrap.frontend.filters
 
-import akka.stream._
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
-import akka.util.ByteString
+import akka.stream.Materializer
 import javax.inject.Inject
-import play.api.Logger
-import play.api.http.HttpEntity.Streamed
-import play.api.http.{HeaderNames, HttpEntity}
-import play.api.libs.streams.Accumulator
-import play.api.mvc._
-import play.api.routing.Router.Attrs
+import play.api.http.HeaderNames
+import play.api.mvc.{RequestHeader, ResponseHeader, Result}
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.audit.EventKeys._
+import uk.gov.hmrc.play.audit.EventKeys
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.model.DataEvent
 import uk.gov.hmrc.play.bootstrap.config.{ControllerConfigs, HttpAuditEvent}
-import uk.gov.hmrc.play.bootstrap.filters.{AuditFilter, RequestBodyCaptor, ResponseBodyCaptor}
+import uk.gov.hmrc.play.bootstrap.filters.CommonAuditFilter
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendHeaderCarrierProvider
 import uk.gov.hmrc.play.bootstrap.frontend.filters.deviceid.DeviceFingerprint
-import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
-import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.ExecutionContext
 
-trait FrontendAuditFilter extends AuditFilter {
-
-  protected implicit def ec: ExecutionContext
-  def auditConnector: AuditConnector
-
-  def dataEvent(
-    eventType: String,
-    transactionName: String,
-    request: RequestHeader,
-    detail: Map[String, String] = Map()
-  )(
-    implicit
-    hc: HeaderCarrier
-  ): DataEvent
-
-  def controllerNeedsAuditing(controllerName: String): Boolean
-
-  private val logger = Logger(getClass)
-
-  private val textHtml = ".*(text/html).*".r
-
-  val maxBodySize = 32665
-
-  val requestReceived = "RequestReceived"
+trait FrontendAuditFilter
+  extends CommonAuditFilter
+     with FrontendHeaderCarrierProvider {
 
   def maskedFormFields: Seq[String]
 
   def applicationPort: Option[Int]
 
-  implicit def mat: Materializer
 
-  override def apply(nextFilter: EssentialAction) = new EssentialAction {
-    def apply(requestHeader: RequestHeader) = {
-      val next: Accumulator[ByteString, Result] = nextFilter(requestHeader)
+  private val textHtml = ".*(text/html).*".r
 
-      implicit val hc = HeaderCarrierConverter.fromRequestAndSession(requestHeader, requestHeader.session)
-
-      val loggingContext = s"${requestHeader.method} ${requestHeader.uri} "
-
-      def performAudit(requestBody: String, tryResult: Try[Result])(responseBody: String): Unit = {
-        val detail = tryResult match {
-          case Success(result) =>
-            val responseHeader = result.header
-            Map(
-                ResponseMessage -> filterResponseBody(result, responseHeader, responseBody),
-                StatusCode      -> responseHeader.status.toString
-              ) ++
-              buildRequestDetails(requestHeader, requestBody) ++
-              buildResponseDetails(responseHeader)
-          case Failure(f) =>
-            Map(FailedRequestMessage -> f.getMessage) ++
-              buildRequestDetails(requestHeader, requestBody)
-        }
-        auditConnector.sendEvent(
-          dataEvent(
-            eventType       = requestReceived,
-            transactionName = requestHeader.uri,
-            request         = requestHeader,
-            detail          = detail
-          )
-        )
-      }
-
-      if (needsAuditing(requestHeader))
-        onCompleteWithInput(loggingContext, next, performAudit)
-      else
-        next
-    }
-  }
-
-  protected def needsAuditing(request: RequestHeader): Boolean =
-    request.attrs.get(Attrs.HandlerDef).forall { handlerDef =>
-      controllerNeedsAuditing(handlerDef.controller)
-    }
-
-  protected def onCompleteWithInput(
-    loggingContext: String,
-    next: Accumulator[ByteString, Result],
-    handler: (String, Try[Result]) => String => Unit)(
-    implicit ec: ExecutionContext): Accumulator[ByteString, Result] = {
-    val requestBodyPromise = Promise[String]()
-    val requestBodyFuture  = requestBodyPromise.future
-
-    var requestBody: String = ""
-    def callback(body: ByteString): Unit = {
-      requestBody = body.decodeString("UTF-8")
-      requestBodyPromise.success(requestBody)
-    }
-
-    //grabbed from plays csrf filter
-    val wrappedAcc: Accumulator[ByteString, Result] = Accumulator(
-      Flow[ByteString]
-        .via(new RequestBodyCaptor(loggingContext, maxBodySize, callback))
-        .splitWhen(_ => false)
-        .prefixAndTail(0)
-        .map(_._2)
-        .concatSubstreams
-        .toMat(Sink.head[Source[ByteString, _]])(Keep.right)
-    ).mapFuture(next.run)
-
-    wrappedAcc
-      .mapFuture { result =>
-        requestBodyFuture.flatMap { res =>
-          val auditedBody = result.body match {
-            case str: Streamed =>
-              val auditFlow = Flow[ByteString].alsoTo(
-                new ResponseBodyCaptor(loggingContext, maxBodySize, handler(requestBody, Success(result))))
-              str.copy(data = str.data.via(auditFlow))
-            case h: HttpEntity =>
-              h.consumeData.map { rb =>
-                val auditString =
-                  if (rb.size > maxBodySize) {
-                    logger.warn(
-                      s"txm play auditing: $loggingContext response body ${rb.size} exceeds maxLength $maxBodySize - do you need to be auditing this payload?")
-                    rb.take(maxBodySize).decodeString("UTF-8")
-                  } else {
-                    rb.decodeString("UTF-8")
-                  }
-                handler(res, Success(result))(auditString)
-              }
-              h
-          }
-          Future(result.copy(body = auditedBody))
-        }
-      }
-      .recover[Result] {
-        case ex: Throwable =>
-          handler(requestBody, Failure(ex))("")
-          throw ex
-      }
-  }
-
-  private def filterResponseBody(result: Result, response: ResponseHeader, responseBody: String) =
+  override protected def filterResponseBody(result: Result, response: ResponseHeader, responseBody: String) =
     result.body.contentType
-      .collect {
-        case textHtml(a) => "<HTML>...</HTML>"
-      }
+      .collect { case textHtml(a) => "<HTML>...</HTML>" }
       .getOrElse(responseBody)
 
-  private def buildRequestDetails(requestHeader: RequestHeader, request: String): Map[String, String] = {
-    val details = new collection.mutable.HashMap[String, String]
+  override protected def buildRequestDetails(requestHeader: RequestHeader, requestBody: String): Map[String, String] =
+    Map(
+      EventKeys.RequestBody -> stripPasswords(requestHeader.contentType, requestBody, maskedFormFields),
+      "deviceFingerprint"   -> DeviceFingerprint.deviceFingerprintFrom(requestHeader),
+      "host"                -> getHost(requestHeader),
+      "port"                -> getPort,
+      "queryString"         -> getQueryString(requestHeader.queryString)
+    )
 
-    details.put(RequestBody, stripPasswords(requestHeader.contentType, request, maskedFormFields))
-    details.put("deviceFingerprint", DeviceFingerprint.deviceFingerprintFrom(requestHeader))
-    details.put("host", getHost(requestHeader))
-    details.put("port", getPort)
-    details.put("queryString", getQueryString(requestHeader.queryString))
-
-    details.toMap
-  }
-
-  private def buildResponseDetails(response: ResponseHeader): Map[String, String] = {
-    val details = new collection.mutable.HashMap[String, String]
-    response.headers.get(HeaderNames.LOCATION).map { location =>
-      details.put(HeaderNames.LOCATION, location)
-    }
-
-    details.toMap
-  }
+  override protected def buildResponseDetails(response: ResponseHeader): Map[String, String] =
+    response.headers.get(HeaderNames.LOCATION)
+      .map(HeaderNames.LOCATION -> _)
+      .toMap
 
   private[filters] def getQueryString(queryString: Map[String, Seq[String]]): String =
-    cleanQueryStringForDatastream(queryString.foldLeft[String]("") { (stringRepresentation, mapOfArgs) =>
-      val spacer = stringRepresentation match {
-        case "" => ""
-        case _  => "&"
-      }
+    cleanQueryStringForDatastream(
+      queryString.map { case (k, vs) => k + ":" + vs.mkString(",") }.mkString("&")
+    )
 
-      stringRepresentation + spacer + mapOfArgs._1 + ":" + getQueryStringValue(mapOfArgs._2)
-    })
-
-  private[filters] def getHost(request: RequestHeader) =
+  private[filters] def getHost(request: RequestHeader): String =
     request.headers.get("Host").map(_.takeWhile(_ != ':')).getOrElse("-")
 
-  private[filters] def getPort = applicationPort.map(_.toString).getOrElse("-")
+  private[filters] def getPort: String =
+    applicationPort.map(_.toString).getOrElse("-")
 
   private[filters] def stripPasswords(
     contentType: Option[String],
     requestBody: String,
-    maskedFormFields: Seq[String]): String =
+    maskedFormFields: Seq[String]
+  ): String =
     contentType match {
       case Some("application/x-www-form-urlencoded") =>
         maskedFormFields.foldLeft(requestBody)((maskedBody, field) =>
@@ -224,22 +84,11 @@ trait FrontendAuditFilter extends AuditFilter {
       case _ => requestBody
     }
 
-  private def getQueryStringValue(seqOfArgs: Seq[String]): String =
-    seqOfArgs.foldLeft(""){
-      (queryStringArrayConcat, queryStringArrayItem) =>
-        val queryStringArrayPrepend = queryStringArrayConcat match {
-          case "" => ""
-          case _  => ","
-        }
-
-        queryStringArrayConcat + queryStringArrayPrepend + queryStringArrayItem
-    }
-
   private def cleanQueryStringForDatastream(queryString: String): String =
     queryString.trim match {
-      case ""  => "-"
-      case ":" => "-" // play 2.5 FakeRequest now parses an empty query string into a two empty string params
-      case _   => queryString.trim
+      case ""    => "-"
+      case ":"   => "-" // play 2.5 FakeRequest now parses an empty query string into a two empty string params
+      case other => other
     }
 }
 
@@ -248,20 +97,21 @@ class DefaultFrontendAuditFilter @Inject()(
   override val auditConnector: AuditConnector,
   httpAuditEvent: HttpAuditEvent,
   override val mat: Materializer
-)(implicit protected val ec: ExecutionContext) extends FrontendAuditFilter {
+)(implicit protected val ec: ExecutionContext
+) extends FrontendAuditFilter {
 
   override val maskedFormFields: Seq[String] = Seq.empty
 
   override val applicationPort: Option[Int] = None
 
-  override def dataEvent(
-    eventType: String,
-    transactionName: String,
-    request: RequestHeader,
-    detail: Map[String, String]
-  )(implicit hc: HeaderCarrier): DataEvent =
-    httpAuditEvent.dataEvent(eventType, transactionName, request, detail)
-
   override def controllerNeedsAuditing(controllerName: String): Boolean =
     controllerConfigs.controllerNeedsAuditing(controllerName)
+
+  override def dataEvent(
+    eventType      : String,
+    transactionName: String,
+    request        : RequestHeader,
+    detail         : Map[String, String]
+  )(implicit hc: HeaderCarrier): DataEvent =
+    httpAuditEvent.dataEvent(eventType, transactionName, request, detail)
 }

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/FrontendAuditFilter.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/FrontendAuditFilter.scala
@@ -94,7 +94,7 @@ trait FrontendAuditFilter
 }
 
 class DefaultFrontendAuditFilter @Inject()(
-  config: Configuration,
+  override val config: Configuration,
   controllerConfigs: ControllerConfigs,
   override val auditConnector: AuditConnector,
   httpAuditEvent: HttpAuditEvent,
@@ -105,9 +105,6 @@ class DefaultFrontendAuditFilter @Inject()(
   override val maskedFormFields: Seq[String] = Seq.empty
 
   override val applicationPort: Option[Int] = None
-
-  override val isAuditingEnabled: Boolean =
-    config.get[Boolean]("auditing.enabled")
 
   override def controllerNeedsAuditing(controllerName: String): Boolean =
     controllerConfigs.controllerNeedsAuditing(controllerName)

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/FrontendFilters.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/FrontendFilters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/HeadersFilter.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/HeadersFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/SessionIdFilter.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/SessionIdFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/SessionTimeoutFilter.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/SessionTimeoutFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/crypto/ApplicationCryptoProvider.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/crypto/ApplicationCryptoProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/crypto/SessionCookieCrypto.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/crypto/SessionCookieCrypto.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/crypto/SessionCookieCryptoFilter.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/crypto/SessionCookieCryptoFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DefaultDeviceIdFilter.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DefaultDeviceIdFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceFingerprint.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceFingerprint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceId.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdCookie.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdCookie.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdFilter.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdFilter.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdFilter.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.play.bootstrap.frontend.filters.deviceid
 
 import play.api.mvc._
 import play.api.mvc.request.{Cell, RequestAttrKey}
-import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.AuditExtensions._
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.model.{DataEvent, EventTypes}

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/http/FrontendErrorHandler.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/http/FrontendErrorHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/package.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/resources/frontend.test.conf
+++ b/bootstrap-frontend-play-26/src/test/resources/frontend.test.conf
@@ -1,4 +1,4 @@
-# Copyright 2020 HM Revenue & Customs
+# Copyright 2021 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/BackwardCompatibilitySpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/BackwardCompatibilitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/BackwardCompatibilitySpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/BackwardCompatibilitySpec.scala
@@ -169,6 +169,7 @@ class BackwardCompatibilitySpec
         override def ec             = mock[ExecutionContext]
         override def auditConnector = mock[uk.gov.hmrc.play.audit.http.connector.AuditConnector]
         override def mat            = mock[Materializer]
+        override val isAuditingEnabled: Boolean = true
         override def controllerNeedsAuditing(controllerName: String): Boolean = true
         override def dataEvent(
           eventType      : String,
@@ -183,6 +184,7 @@ class BackwardCompatibilitySpec
 
     "preserve uk.gov.hmrc.play.bootstrap.filters.frontend.DefaultFrontendAuditFilter" in {
       new uk.gov.hmrc.play.bootstrap.filters.frontend.DefaultFrontendAuditFilter(
+        config            = mock[Configuration],
         controllerConfigs = mock[uk.gov.hmrc.play.bootstrap.config.ControllerConfigs],
         auditConnector    = mock[uk.gov.hmrc.play.audit.http.connector.AuditConnector],
         httpAuditEvent    = mock[uk.gov.hmrc.play.bootstrap.config.HttpAuditEvent],

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/BackwardCompatibilitySpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/BackwardCompatibilitySpec.scala
@@ -167,9 +167,9 @@ class BackwardCompatibilitySpec
     "preserve uk.gov.hmrc.play.bootstrap.filters.frontend.FrontendAuditFilter" in {
       new uk.gov.hmrc.play.bootstrap.filters.frontend.FrontendAuditFilter {
         override def ec             = mock[ExecutionContext]
+        override def config         = mock[Configuration]
         override def auditConnector = mock[uk.gov.hmrc.play.audit.http.connector.AuditConnector]
         override def mat            = mock[Materializer]
-        override val isAuditingEnabled: Boolean = true
         override def controllerNeedsAuditing(controllerName: String): Boolean = true
         override def dataEvent(
           eventType      : String,

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/FrontendConfigLoadSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/FrontendConfigLoadSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/controller/FrontendHeaderCarrierProviderSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/controller/FrontendHeaderCarrierProviderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/AllowlistFilterSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/AllowlistFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/DefaultSessionCookieCryptoFilterSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/DefaultSessionCookieCryptoFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/FrontendAuditFilterSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/FrontendAuditFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/HeadersFilterSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/HeadersFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/SessionIdFilterSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/SessionIdFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/SessionTimeoutFilterSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/SessionTimeoutFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/crypto/SessionCookieCryptoFilterSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/crypto/SessionCookieCryptoFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DefaultDeviceIdFilterSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DefaultDeviceIdFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdFilterSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/http/FrontendErrorHandlerSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/http/FrontendErrorHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/logging/MDCFrontendLoggingSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/logging/MDCFrontendLoggingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-health-play-26/src/main/resources/reference.conf
+++ b/bootstrap-health-play-26/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright 2020 HM Revenue & Customs
+# Copyright 2021 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bootstrap-health-play-26/src/main/scala/health/HealthController.scala
+++ b/bootstrap-health-play-26/src/main/scala/health/HealthController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-health-play-26/src/main/scala/health/HealthRoutes.scala
+++ b/bootstrap-health-play-26/src/main/scala/health/HealthRoutes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-health-play-26/src/test/scala/health/HealthRoutesSpec.scala
+++ b/bootstrap-health-play-26/src/test/scala/health/HealthRoutesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-test-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/tools/Stubs.scala
+++ b/bootstrap-test-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/tools/Stubs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bootstrap-test-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/logging/MDCLoggingSpec.scala
+++ b/bootstrap-test-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/logging/MDCLoggingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -83,10 +83,10 @@ lazy val bootstrapHealthPlay26 = Project("bootstrap-health-play-26", file("boots
   )
 
   def copySources(module: Project) = Seq(
-    Compile / scalaSource := (module / Compile / scalaSource).value,
-    Compile / resources   := (module / Compile / resources).value,
-    Test    / scalaSource := (module / Test    / scalaSource).value,
-    Test    / resources   := (module / Test    / resources).value
+    Compile / scalaSource       := (module / Compile / scalaSource).value,
+    Compile / resourceDirectory := (module / Compile / resourceDirectory).value,
+    Test    / scalaSource       := (module / Test    / scalaSource).value,
+    Test    / resourceDirectory := (module / Test    / resourceDirectory).value
   )
 
 lazy val bootstrapCommonPlay27 = Project("bootstrap-common-play-27", file("bootstrap-common-play-27"))


### PR DESCRIPTION
Refactors commonality between Frontend and Backend AuditFilters.
Filters check the `auditing.enabled` flag before calling play-auduting.
The default `auditing.enabled` value has been moved into configuration. Note, this still defaults to `true` even though it is only partially configured, and will fail with "missing auditing.consumer configuration". It requires applications to override to false, or add the missing configuration.