### PR TITLE
BDOG-1312: Allow deviceId cookie secure property to be set via config

### DIFF
--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/package.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/package.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.play
 import uk.gov.hmrc.play.bootstrap.binders.{AbsoluteWithHostnameFromAllowlist, RedirectUrlPolicy}
 import scala.concurrent.{ExecutionContext, Future}
 
-package boostrap {
+package bootstrap {
 
   package object binders {
 

--- a/bootstrap-frontend-play-26/src/main/resources/frontend.conf
+++ b/bootstrap-frontend-play-26/src/main/resources/frontend.conf
@@ -23,6 +23,7 @@ cookie.encryption.key = "gvBoGdgzqG1AarzF1LY0zQ=="
 queryParameter.encryption = ${cookie.encryption}
 sso.encryption.key = "P5xsJ9Nt+quxGZzB4DeLfw=="
 cookie.deviceId.secret = "some_secret"
+cookie.deviceId.secure = true
 
 # Use legacy way of encoding cookies instead of JWT which is the default in Play 2.6
 play.modules.disabled += "play.api.mvc.CookiesModule"

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DefaultDeviceIdFilter.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DefaultDeviceIdFilter.scala
@@ -38,4 +38,7 @@ class DefaultDeviceIdFilter @Inject()(
 
   override lazy val previousSecrets: Seq[String] =
     configuration.get[Seq[String]]("cookie.deviceId.previous.secret")
+
+  override lazy val secure: Boolean =
+    configuration.get[Boolean]("cookie.deviceId.secure")
 }

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdCookie.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdCookie.scala
@@ -21,9 +21,9 @@ import java.util.UUID
 import play.api.mvc.Cookie
 
 trait DeviceIdCookie {
-  val secret: String
-  val previousSecrets: Seq[String]
-  val secure: Boolean
+  def secret: String
+  def previousSecrets: Seq[String]
+  def secure: Boolean
 
   def getTimeStamp = System.currentTimeMillis()
 

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdCookie.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdCookie.scala
@@ -23,6 +23,7 @@ import play.api.mvc.Cookie
 trait DeviceIdCookie {
   val secret: String
   val previousSecrets: Seq[String]
+  val secure: Boolean
 
   def getTimeStamp = System.currentTimeMillis()
 
@@ -39,5 +40,5 @@ trait DeviceIdCookie {
   }
 
   def makeCookie(deviceId: DeviceId) =
-    Cookie(DeviceId.MdtpDeviceId, deviceId.value, Some(DeviceId.TenYears), secure = true)
+    Cookie(DeviceId.MdtpDeviceId, deviceId.value, Some(DeviceId.TenYears), secure = secure)
 }

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdFilter.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdFilter.scala
@@ -44,7 +44,7 @@ trait DeviceIdFilter extends Filter with DeviceIdCookie {
 
           case Some(deviceId) =>
             // Valid new format cookie.
-            // Ensure the cookie is secure by setting it again with the secure flag
+            // Ensure the cookie has appropriate 'secure' flag by setting it again, this will also extend the life of the cookie
             val secureDeviceIdCookie = buildNewDeviceIdCookie().copy(value = deviceId.value)
             CookieResult(allCookiesApartFromDeviceId.toSeq :+ secureDeviceIdCookie, secureDeviceIdCookie)
 

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/BackwardCompatibilitySpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/BackwardCompatibilitySpec.scala
@@ -142,6 +142,7 @@ class BackwardCompatibilitySpec
       new uk.gov.hmrc.play.bootstrap.filters.frontend.deviceid.DeviceIdCookie {
         override val secret          = ""
         override val previousSecrets = Seq.empty
+        override val secure          = true
       }
     }
 
@@ -152,6 +153,7 @@ class BackwardCompatibilitySpec
         override def appName         = ""
         override val previousSecrets = mock[Seq[String]]
         override val secret          = ""
+        override val secure          = true
         override def mat             = mock[Materializer]
       }
     }

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DefaultDeviceIdFilterSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DefaultDeviceIdFilterSpec.scala
@@ -88,6 +88,20 @@ class DefaultDeviceIdFilterSpec
         mdtpidCookieValue should include(uuid)
       }
     }
+
+    "set cookie's secure property based on config" in {
+
+      Seq(true, false).foreach { secureCookie =>
+        running(application(having = appConfig + ("cookie.deviceId.secure" -> secureCookie))) { application =>
+          val Some(result) = route(application, FakeRequest(GET, "/test"))
+          val deviceIdCookie = cookies(result).get(DeviceId.MdtpDeviceId)
+          deviceIdCookie shouldBe 'defined
+          deviceIdCookie.get.secure shouldBe secureCookie
+        }
+      }
+
+
+    }
   }
 
   private val theSecret         = "some_secret"
@@ -96,9 +110,10 @@ class DefaultDeviceIdFilterSpec
   private val createDeviceId = new DeviceIdCookie {
     override val secret          = theSecret
     override val previousSecrets = Seq(thePreviousSecret)
+    override val secure          = true
   }
 
-  private val appConfigNoPreviousKey: Map[String, Any] = Map("cookie.deviceId.secret" -> theSecret)
+  private val appConfigNoPreviousKey: Map[String, Any] = Map("cookie.deviceId.secret" -> theSecret, "cookie.deviceId.secure" -> true)
   private val appConfig: Map[String, Any] = appConfigNoPreviousKey + ("cookie.deviceId.previous.secret" -> Seq(
     thePreviousSecret))
 

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DefaultDeviceIdFilterSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DefaultDeviceIdFilterSpec.scala
@@ -99,8 +99,6 @@ class DefaultDeviceIdFilterSpec
           deviceIdCookie.get.secure shouldBe secureCookie
         }
       }
-
-
     }
   }
 

--- a/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdFilterSpec.scala
+++ b/bootstrap-frontend-play-26/src/test/scala/uk/gov/hmrc/play/bootstrap/frontend/filters/deviceid/DeviceIdFilterSpec.scala
@@ -160,7 +160,7 @@ class DeviceIdFilterSpec
       responseCookie.secure shouldBe true
     }
 
-    "not change the request or the response when a valid new format mtdpdi cookie exists" in new Setup {
+    "not change the request or the response when a valid new format mdtpdi cookie exists" in new Setup {
       val result = invokeFilter(filter)(Seq(newFormatGoodCookieDeviceId, normalCookie), newFormatGoodCookieDeviceId)
 
       val expectedCookie1 = requestPassedToAction().cookies.get("AnotherCookie1").get
@@ -174,7 +174,7 @@ class DeviceIdFilterSpec
       responseCookie.secure shouldBe true
     }
 
-    "respect mtdpdi cookie secure setting, keeping the same value - starting with secure=false" in new Setup {
+    "respect mdtpdi cookie secure setting, keeping the same value - starting with secure=false" in new Setup {
       override lazy val filter = makeFilter(secureCookie = true)
 
       val result =
@@ -191,7 +191,7 @@ class DeviceIdFilterSpec
       responseCookie.secure shouldBe true
     }
 
-    "respect mtdpdi cookie secure setting, keeping the same value - starting with secure=true" in new Setup {
+    "respect mdtpdi cookie secure setting, keeping the same value - starting with secure=true" in new Setup {
       override lazy val filter = makeFilter(secureCookie = false)
 
       val result =
@@ -207,8 +207,6 @@ class DeviceIdFilterSpec
       responseCookie.value  shouldBe newFormatGoodCookieDeviceId.value
       responseCookie.secure shouldBe false
     }
-
-
 
     "identify new format deviceId cookie has invalid hash and create new deviceId cookie" in new Setup {
 


### PR DESCRIPTION
At present, it is hardcoded to be secure. This means one needs to run
with HTTPS locally to see it being sent from the browser to the server.

We intend to configure it to 'true' everywhere, apart from during tests
runs on developers machines.