### PR TITLE
DLK 714 audit counters

### DIFF
--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/AuditModule.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/AuditModule.scala
@@ -18,12 +18,14 @@ package uk.gov.hmrc.play.bootstrap
 
 import play.api.inject.{Binding, Module}
 import play.api.{Configuration, Environment}
-import uk.gov.hmrc.play.audit.http.connector.AuditConnector
-import uk.gov.hmrc.play.bootstrap.audit.DefaultAuditConnector
+import uk.gov.hmrc.play.audit.http.connector.{AuditChannel, AuditCounter, AuditConnector}
+import uk.gov.hmrc.play.bootstrap.audit.{DefaultAuditChannel, DefaultAuditCounter, DefaultAuditConnector}
 
 class AuditModule extends Module {
 
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
+    bind[AuditChannel].to[DefaultAuditChannel],
+    bind[AuditCounter].to[DefaultAuditCounter],
     bind[AuditConnector].to[DefaultAuditConnector]
   )
 }

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/audit/DefaultAuditChannel.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/audit/DefaultAuditChannel.scala
@@ -18,13 +18,13 @@ package uk.gov.hmrc.play.bootstrap.audit
 
 import akka.stream.Materializer
 import javax.inject.{Inject, Singleton}
+import play.api.inject.ApplicationLifecycle
 import uk.gov.hmrc.play.audit.http.config.AuditingConfig
-import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditChannel, AuditCounter}
+import uk.gov.hmrc.play.audit.http.connector.AuditChannel
 
 @Singleton
-class DefaultAuditConnector @Inject()(
+class DefaultAuditChannel @Inject()(
   val auditingConfig: AuditingConfig,
   val materializer  : Materializer,
-  val auditChannel  : AuditChannel,
-  val auditCounter  : AuditCounter
-) extends AuditConnector
+  val lifecycle     : ApplicationLifecycle
+) extends AuditChannel

--- a/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/audit/DefaultAuditCounter.scala
+++ b/bootstrap-common-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/audit/DefaultAuditCounter.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.bootstrap.audit
+
+import akka.actor.{ActorSystem, CoordinatedShutdown}
+import com.codahale.metrics.Gauge
+import com.codahale.metrics.MetricRegistry.MetricSupplier
+import com.kenshoo.play.metrics.Metrics
+import javax.inject.{Inject, Singleton}
+import uk.gov.hmrc.play.audit.http.config.AuditingConfig
+import uk.gov.hmrc.play.audit.http.connector.{AuditChannel, AuditCounter, AuditCounterMetrics}
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class DefaultAuditCounter @Inject()(
+  val actorSystem: ActorSystem,
+  val auditingConfig: AuditingConfig,
+  val coordinatedShutdown : CoordinatedShutdown,
+  val ec : ExecutionContext,
+  val auditChannel:AuditChannel,
+  metrics: Metrics
+) extends AuditCounter {
+  lazy val auditMetrics = new AuditCounterMetrics {
+    def registerMetric(name:String, read:()=>Long):Unit = {
+      metrics.defaultRegistry.gauge(name, new MetricSupplier[Gauge[_]] {
+        override def newMetric(): Gauge[_] = new Gauge[Long] {
+          override def getValue: Long = read()
+        }
+      })
+    }
+  }
+}

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -30,7 +30,7 @@ object LibDependencies {
       "uk.gov.hmrc"             %% "auth-client"                % s"4.0.0-$playSuffix",
       "uk.gov.hmrc"             %% "crypto"                     % "6.0.0",
       "uk.gov.hmrc"             %% s"http-verbs-$playSuffix"    % "13.3.0",
-      "uk.gov.hmrc"             %% s"play-auditing-$playSuffix" % "7.1.0",
+      "uk.gov.hmrc"             %% s"play-auditing-$playSuffix" % "7.2.0-SNAPSHOT",
       // the following are not used by bootstrap - but transitively added for clients
       "com.typesafe.play"       %% "filters-helpers"            % playVersion,
       "uk.gov.hmrc"             %% "logback-json-logger"        % "5.1.0",


### PR DESCRIPTION
Upgrades the version of play-auditing to include auditing counters

These are needed to detect and measure audit loss

See https://confluence.tools.tax.service.gov.uk/display/TM/Auditing+Counters