### PR TITLE
DLK-714 Enable writing audit counters to logs (cast to logback)

### DIFF
--- a/bootstrap-common-play-27/src/main/scala/uk/gov/hmrc/play/bootstrap/AuditModule.scala
+++ b/bootstrap-common-play-27/src/main/scala/uk/gov/hmrc/play/bootstrap/AuditModule.scala
@@ -18,14 +18,15 @@ package uk.gov.hmrc.play.bootstrap
 
 import play.api.inject.{Binding, Module}
 import play.api.{Configuration, Environment}
-import uk.gov.hmrc.play.audit.http.connector.{AuditChannel, AuditConnector, AuditCounter, AuditCounterMetrics}
-import uk.gov.hmrc.play.bootstrap.audit.{DefaultAuditChannel, DefaultAuditConnector, DefaultAuditCounter, DefaultAuditCounterMetrics}
+import uk.gov.hmrc.play.audit.http.connector.{AuditChannel, AuditConnector, AuditCounter, AuditCounterLogs, AuditCounterMetrics}
+import uk.gov.hmrc.play.bootstrap.audit.{DefaultAuditChannel, DefaultAuditConnector, DefaultAuditCounter, DefaultAuditCounterLogs, DefaultAuditCounterMetrics}
 
 class AuditModule extends Module {
 
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
     bind[AuditChannel].to[DefaultAuditChannel],
     bind[AuditCounterMetrics].to[DefaultAuditCounterMetrics],
+    bind[AuditCounterLogs].to[DefaultAuditCounterLogs],
     bind[AuditCounter].to[DefaultAuditCounter],
     bind[AuditConnector].to[DefaultAuditConnector]
   )

--- a/bootstrap-common-play-27/src/main/scala/uk/gov/hmrc/play/bootstrap/audit/DefaultAuditCounter.scala
+++ b/bootstrap-common-play-27/src/main/scala/uk/gov/hmrc/play/bootstrap/audit/DefaultAuditCounter.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.play.bootstrap.audit
 
 import akka.actor.{ActorSystem, CoordinatedShutdown}
 import uk.gov.hmrc.play.audit.http.config.AuditingConfig
-import uk.gov.hmrc.play.audit.http.connector.{AuditChannel, AuditCounterMetrics, PublishedAuditCounter}
+import uk.gov.hmrc.play.audit.http.connector.{AuditChannel, AuditCounterLogs, AuditCounterMetrics, PublishedAuditCounter}
 import javax.inject.{Inject, Singleton}
 
 import scala.concurrent.ExecutionContext
@@ -29,4 +29,5 @@ class DefaultAuditCounter @Inject()(val actorSystem: ActorSystem,
                                     val auditingConfig: AuditingConfig,
                                     val auditChannel: AuditChannel,
                                     val auditMetrics: AuditCounterMetrics,
+                                    val auditCounterLogs: AuditCounterLogs,
                                     ec: ExecutionContext) extends PublishedAuditCounter(actorSystem, coordinatedShutdown)(ec)

--- a/bootstrap-common-play-27/src/main/scala/uk/gov/hmrc/play/bootstrap/audit/DefaultAuditCounterLogs.scala
+++ b/bootstrap-common-play-27/src/main/scala/uk/gov/hmrc/play/bootstrap/audit/DefaultAuditCounterLogs.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.bootstrap.audit
+
+import ch.qos.logback.classic.{Level, Logger}
+import org.slf4j.LoggerFactory
+import uk.gov.hmrc.play.audit.http.connector.AuditCounterLogs
+
+class DefaultAuditCounterLogs extends AuditCounterLogs {
+
+  private val logger = LoggerFactory.getLogger("play-auditing")
+  logger.asInstanceOf[Logger].setLevel(Level.INFO)
+
+  override def logInfo(message: String): Unit = {
+    logger.info(message)
+  }
+
+}

--- a/bootstrap-common-play-28/src/main/scala/uk/gov/hmrc/play/bootstrap/AuditModule.scala
+++ b/bootstrap-common-play-28/src/main/scala/uk/gov/hmrc/play/bootstrap/AuditModule.scala
@@ -18,14 +18,15 @@ package uk.gov.hmrc.play.bootstrap
 
 import play.api.inject.{Binding, Module}
 import play.api.{Configuration, Environment}
-import uk.gov.hmrc.play.audit.http.connector.{AuditChannel, AuditConnector, AuditCounter, AuditCounterMetrics}
-import uk.gov.hmrc.play.bootstrap.audit.{DefaultAuditChannel, DefaultAuditConnector, DefaultAuditCounter, DefaultAuditCounterMetrics}
+import uk.gov.hmrc.play.audit.http.connector.{AuditChannel, AuditConnector, AuditCounter, AuditCounterLogs, AuditCounterMetrics}
+import uk.gov.hmrc.play.bootstrap.audit.{DefaultAuditChannel, DefaultAuditConnector, DefaultAuditCounter, DefaultAuditCounterLogs, DefaultAuditCounterMetrics}
 
 class AuditModule extends Module {
 
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
     bind[AuditChannel].to[DefaultAuditChannel],
     bind[AuditCounterMetrics].to[DefaultAuditCounterMetrics],
+    bind[AuditCounterLogs].to[DefaultAuditCounterLogs],
     bind[AuditCounter].to[DefaultAuditCounter],
     bind[AuditConnector].to[DefaultAuditConnector]
   )

--- a/bootstrap-common-play-28/src/main/scala/uk/gov/hmrc/play/bootstrap/audit/DefaultAuditCounter.scala
+++ b/bootstrap-common-play-28/src/main/scala/uk/gov/hmrc/play/bootstrap/audit/DefaultAuditCounter.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.play.bootstrap.audit
 
 import akka.actor.{ActorSystem, CoordinatedShutdown}
 import uk.gov.hmrc.play.audit.http.config.AuditingConfig
-import uk.gov.hmrc.play.audit.http.connector.{AuditChannel, AuditCounterMetrics, PublishedAuditCounter}
+import uk.gov.hmrc.play.audit.http.connector.{AuditChannel, AuditCounterLogs, AuditCounterMetrics, PublishedAuditCounter}
 import javax.inject.{Inject, Singleton}
 
 import scala.concurrent.ExecutionContext
@@ -29,4 +29,5 @@ class DefaultAuditCounter @Inject()(val actorSystem: ActorSystem,
                                     val auditingConfig: AuditingConfig,
                                     val auditChannel: AuditChannel,
                                     val auditMetrics: AuditCounterMetrics,
+                                    val auditCounterLogs: AuditCounterLogs,
                                     ec: ExecutionContext) extends PublishedAuditCounter(actorSystem, coordinatedShutdown)(ec)

--- a/bootstrap-common-play-28/src/main/scala/uk/gov/hmrc/play/bootstrap/audit/DefaultAuditCounterLogs.scala
+++ b/bootstrap-common-play-28/src/main/scala/uk/gov/hmrc/play/bootstrap/audit/DefaultAuditCounterLogs.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.bootstrap.audit
+
+import ch.qos.logback.classic.{Level, Logger}
+import org.slf4j.LoggerFactory
+import uk.gov.hmrc.play.audit.http.connector.AuditCounterLogs
+
+class DefaultAuditCounterLogs extends AuditCounterLogs {
+
+  private val logger = LoggerFactory.getLogger("play-auditing")
+  logger.asInstanceOf[Logger].setLevel(Level.INFO)
+
+  override def logInfo(message: String): Unit = {
+    logger.info(message)
+  }
+
+}

--- a/bootstrap-common/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AuditingConfigProvider.scala
+++ b/bootstrap-common/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AuditingConfigProvider.scala
@@ -44,10 +44,11 @@ class AuditingConfigProvider @Inject()(
                               )
                             ),
         auditSource       = appName,
-        auditSentHeaders  = c.get[Boolean]("auditSentHeaders")
+        auditSentHeaders  = c.get[Boolean]("auditSentHeaders"),
+        publishCountersToLogs = c.getOptional[Boolean]("publishCountersToLogs").getOrElse(true)
       )
     } else
-      AuditingConfig(consumer = None, enabled = false, auditSource = "auditing disabled", auditSentHeaders = false)
+      AuditingConfig(consumer = None, enabled = false, auditSource = "auditing disabled", auditSentHeaders = false, publishCountersToLogs = false)
   }
 
   private def getRequired[T: play.api.ConfigLoader](config: Configuration, key: String, errMsg: => String): T =

--- a/bootstrap-common/src/test/scala/uk/gov/hmrc/play/bootstrap/config/AuditingConfigProviderSpec.scala
+++ b/bootstrap-common/src/test/scala/uk/gov/hmrc/play/bootstrap/config/AuditingConfigProviderSpec.scala
@@ -41,7 +41,8 @@ class AuditingConfigProviderSpec extends AnyWordSpec with Matchers with MockitoS
         consumer         = Some(Consumer(BaseUri("localhost", 8100, "http"))),
         enabled          = true,
         auditSource      = appName,
-        auditSentHeaders = false
+        auditSentHeaders = false,
+        publishCountersToLogs = true
       )
     }
 
@@ -54,7 +55,27 @@ class AuditingConfigProviderSpec extends AnyWordSpec with Matchers with MockitoS
         consumer         = None,
         enabled          = false,
         auditSource      = "auditing disabled",
-        auditSentHeaders = false
+        auditSentHeaders = false,
+        publishCountersToLogs = false
+      )
+    }
+
+    "allow publishCountersToLogs to be disabled" in {
+      val configuration = Configuration(
+        "auditing.enabled"               -> "true",
+        "auditing.traceRequests"         -> "true",
+        "auditing.consumer.baseUri.host" -> "localhost",
+        "auditing.consumer.baseUri.port" -> "8100",
+        "auditing.auditSentHeaders"      -> "false",
+        "auditing.publishCountersToLogs" -> "false"
+      )
+
+      new AuditingConfigProvider(configuration, appName).get() shouldBe AuditingConfig(
+        consumer         = Some(Consumer(BaseUri("localhost", 8100, "http"))),
+        enabled          = true,
+        auditSource      = appName,
+        auditSentHeaders = false,
+        publishCountersToLogs = false
       )
     }
   }

--- a/bootstrap-common/src/test/scala/uk/gov/hmrc/play/bootstrap/http/utils/TestAuditConnector.scala
+++ b/bootstrap-common/src/test/scala/uk/gov/hmrc/play/bootstrap/http/utils/TestAuditConnector.scala
@@ -28,7 +28,8 @@ class TestAuditConnector(appName: String) extends AuditConnector {
     consumer = None,
     enabled = false,
     auditSource = appName,
-    auditSentHeaders = false
+    auditSentHeaders = false,
+    publishCountersToLogs = false
   )
   override val auditingConfig: AuditingConfig = _auditingConfig
 

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -30,7 +30,7 @@ object LibDependencies {
       "uk.gov.hmrc"             %% "auth-client"                % s"5.6.0-$playSuffix",
       "uk.gov.hmrc"             %% "crypto"                     % "6.0.0",
       "uk.gov.hmrc"             %% s"http-verbs-$playSuffix"    % "13.3.0",
-      "uk.gov.hmrc"             %% s"play-auditing-$playSuffix" % "7.3.0",
+      "uk.gov.hmrc"             %% s"play-auditing-$playSuffix" % "7.4.0",
       // the following are not used by bootstrap - but transitively added for clients
       "com.typesafe.play"       %% "filters-helpers"            % playVersion,
       "uk.gov.hmrc"             %% "logback-json-logger"        % "5.1.0",


### PR DESCRIPTION
Audit counters are needed to detect audit loss so they need to be more
relible than the audits themselves. For this reason audit counters are
published as audits, logs & metrics.

Publising audit counters as logs means that info level logs must be written
even when the individual microservice has not enabled info level logging.

This change programatially sets the logging level to INFO for the play-auditing
logger.
It does assume that logback is used as the slf4j backend so this would
need to be updated if that changed