### PR TITLE
PLATUI-898: add a standardErrorTemplate fallback for client errors

### DIFF
--- a/bootstrap-frontend-play-26/src/main/resources/messages
+++ b/bootstrap-frontend-play-26/src/main/resources/messages
@@ -7,3 +7,6 @@ global.error.pageNotFound404.message=Please check that you have entered the corr
 global.error.InternalServerError500.title=Sorry, we are experiencing technical difficulties - 500
 global.error.InternalServerError500.heading=Sorry, we’re experiencing technical difficulties
 global.error.InternalServerError500.message=Please try again in a few minutes.
+global.error.fallbackClientError4xx.title=Sorry, there is a problem with the service
+global.error.fallbackClientError4xx.heading=Sorry, there is a problem with the service
+global.error.fallbackClientError4xx.message=Try again later.

--- a/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/http/FrontendErrorHandler.scala
+++ b/bootstrap-frontend-play-26/src/main/scala/uk/gov/hmrc/play/bootstrap/frontend/http/FrontendErrorHandler.scala
@@ -37,11 +37,7 @@ abstract class FrontendErrorHandler extends HttpErrorHandler with I18nSupport {
     statusCode match {
       case play.mvc.Http.Status.BAD_REQUEST => Future.successful(BadRequest(badRequestTemplate(request)))
       case play.mvc.Http.Status.NOT_FOUND   => Future.successful(NotFound(notFoundTemplate(request)))
-      case _                                =>
-        implicit val _request: RequestHeader = request // Play27 needs this, as views.html.defaultpages.badRequest now takes an implicit too
-        // This is copied from GlobalSettingsHttpErrorHandler for backward compatibility
-        Future.successful(
-          Results.Status(statusCode)(views.html.defaultpages.badRequest(request.method, request.uri, message)))
+      case _                                => Future.successful(Results.Status(statusCode)(fallbackClientErrorTemplate(request)))
     }
 
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
@@ -64,6 +60,12 @@ abstract class FrontendErrorHandler extends HttpErrorHandler with I18nSupport {
       Messages("global.error.pageNotFound404.title"),
       Messages("global.error.pageNotFound404.heading"),
       Messages("global.error.pageNotFound404.message"))
+
+  def fallbackClientErrorTemplate(implicit request: Request[_]): Html =
+    standardErrorTemplate(
+      Messages("global.error.fallbackClientError4xx.title"),
+      Messages("global.error.fallbackClientError4xx.heading"),
+      Messages("global.error.fallbackClientError4xx.message"))
 
   def internalServerErrorTemplate(implicit request: Request[_]): Html =
     standardErrorTemplate(


### PR DESCRIPTION
Currently the fallback for client errors other than 400 and 404 is to a default play error template

So for example if a request required a CSRF token which wasn't supplied you could get a 403 forbidden rendered as:

![image](https://user-images.githubusercontent.com/100650/122088184-6cc1eb00-cdfd-11eb-8154-33afd5eefb10.png)

@matthewmascord raised an initial draft which explicitly handled CSRF errors and based on feedback we've expanded the change to instead replace the default play fallback template

Content follows GDS guidance for There is a problem with the service:
https://design-system.service.gov.uk/patterns/problem-with-the-service-pages/

We will also be looking to submit a PR to add welsh translations for the global.error messages in the near future