### PR TITLE
PLATUI-898: add welsh translations for FrontendErrorHandler messages

### DIFF
--- a/bootstrap-frontend-play-26/src/main/resources/messages.cy
+++ b/bootstrap-frontend-play-26/src/main/resources/messages.cy
@@ -1,0 +1,12 @@
+global.error.badRequest400.title=Cais gwallus – 400
+global.error.badRequest400.heading=Cais gwallus
+global.error.badRequest400.message=Gwiriwch eich bod wedi nodi’r cyfeiriad gwe cywir.
+global.error.pageNotFound404.title=Heb ddod o hyd i’r dudalen – 404
+global.error.pageNotFound404.heading=Ni ellir dod o hyd i’r dudalen hon
+global.error.pageNotFound404.message=Gwiriwch eich bod wedi nodi’r cyfeiriad gwe cywir.
+global.error.InternalServerError500.title=Mae’n ddrwg gennym - rydym yn profi anawsterau technegol – 500
+global.error.InternalServerError500.heading=Mae’n ddrwg gennym - rydym yn profi anawsterau technegol
+global.error.InternalServerError500.message=Rhowch gynnig arall arni mewn ychydig o funudau.
+global.error.fallbackClientError4xx.title=Mae’n ddrwg gennym - mae problem gyda’r gwasanaeth
+global.error.fallbackClientError4xx.heading=Mae’n ddrwg gennym - mae problem gyda’r gwasanaeth
+global.error.fallbackClientError4xx.message=Rhowch gynnig arall arni yn nes ymlaen.


### PR DESCRIPTION
Translated and screenshots approved by WLU (under reference CYF-6-21-0098 - if it ever needs to be looked up)

I added some tests to catch if explicit handling for a new exception is introduced without a welsh translation being provided

You can see the screenshots of the english / welsh translations tested via a local implementation that I used to get sign off from WLU at https://jira.tools.tax.service.gov.uk/browse/PLATUI-898?focusedCommentId=1379255&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1379255