### PR TITLE
dlk-855: include play-auditing error catching improvements

### DIFF
--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -33,7 +33,7 @@ object LibDependencies {
       "uk.gov.hmrc"             %% "auth-client"                % s"5.6.0-$playSuffix",
       "uk.gov.hmrc"             %% "crypto"                     % "6.0.0",
       "uk.gov.hmrc"             %% s"http-verbs-$playSuffix"    % httpVerbsVersion,
-      "uk.gov.hmrc"             %% s"play-auditing-$playSuffix" % "7.3.0",
+      "uk.gov.hmrc"             %% s"play-auditing-$playSuffix" % "7.7.0",
       // the following are not used by bootstrap - but transitively added for clients
       "com.typesafe.play"       %% "filters-helpers"            % playVersion,
       "uk.gov.hmrc"             %% "logback-json-logger"        % "5.1.0",

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -33,7 +33,7 @@ object LibDependencies {
       "uk.gov.hmrc"             %% "auth-client"                % s"5.6.0-$playSuffix",
       "uk.gov.hmrc"             %% "crypto"                     % "6.0.0",
       "uk.gov.hmrc"             %% s"http-verbs-$playSuffix"    % httpVerbsVersion,
-      "uk.gov.hmrc"             %% s"play-auditing-$playSuffix" % "7.7.0",
+      "uk.gov.hmrc"             %% s"play-auditing-$playSuffix" % "7.8.0",
       // the following are not used by bootstrap - but transitively added for clients
       "com.typesafe.play"       %% "filters-helpers"            % playVersion,
       "uk.gov.hmrc"             %% "logback-json-logger"        % "5.1.0",


### PR DESCRIPTION
We've encountered some errors that weren't being properly
 caught + sent to audit-sweep when services were trying to 
send data to datastream.  

This upgrade catches all synchonrous and asynchronous 
errors, turning them into HandlerResult.Failures that get 
reliably sent to audit-sweep for retry.

You can see the corresponding play-auditing changes
at https://github.com/hmrc/play-auditing/compare/v7.3.0...v7.7.0