### PR TITLE
PLATUI-1404: add default auditing config for common asset controllers

### DIFF
--- a/bootstrap-frontend-play-26/src/main/resources/frontend.conf
+++ b/bootstrap-frontend-play-26/src/main/resources/frontend.conf
@@ -72,6 +72,18 @@ controllers {
     needsLogging = false
     needsAuditing = false
   }
+  # Play's built-in controller for serving static assets
+  controllers.Assets {
+    needsAuditing = false
+  }
+  # play-frontend-govuk assets controller
+  uk.gov.hmrc.govukfrontend.controllers.Assets {
+    needsAuditing = false
+  }
+  # play-frontend-hmrc assets controller
+  uk.gov.hmrc.hmrcfrontend.controllers.Assets {
+    needsAuditing = false
+  }
 }
 
 caching.allowedContentTypes = ["image/", "text/css", "application/javascript"]


### PR DESCRIPTION
As discussed at https://hmrcdigital.slack.com/archives/C0GS60DK2/p1634117754362900

Not disabling auditing for static assets is causing a large increase in the cost of data storage for the CIP team