### PR TITLE
BDOG-500 Add AsyncFrontendErrorHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ play.server.provider = play.core.server.AkkaHttpServerProvider
 
 ## Changes
 
+### Version 7.2.0
+
+Adds `AsyncFrontendErrorHandler` as an async alternative to `FrontendErrorHandler`
+
 ### Version 7.0.0
 
 #### crypto

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -47,7 +47,6 @@ object LibDependencies {
       "org.mockito"             %% "mockito-scala-scalatest"    % "1.16.23"      % Test,
       "com.vladsch.flexmark"    %  "flexmark-all"               % "0.35.10"      % Test,
       "org.scalacheck"          %% "scalacheck"                 % "1.15.2"       % Test,
-      "org.mockito"             %% "mockito-scala-scalatest"    % "1.16.49"      % Test,
       "org.scalatestplus.play"  %% "scalatestplus-play"         % scalaTestPlusPlayVersion(playVersion) % Test,
       "org.scalatestplus"       %% "scalatestplus-scalacheck"   % "3.1.0.0-RC2"  % Test
     )


### PR DESCRIPTION
Note, AsyncFrontendErrorHandler uses `RequestHeader` rather than `Request[_]` (and avoids the implicit conversion `rhToRequest`). It would require templates to be updated to use the same abstraction, but since the body is unavailable in the fake Request anyway, this seems desirable.