### PR TITLE
BDOG-701 Revert use of MDCPropagatingExecutorServiceConfigurator

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,18 +192,6 @@ If you would like the same functionality in `Dev` mode, you must use the older
 play.server.provider = play.core.server.AkkaHttpServerProvider
 ```
 
-#### `ExecutionContext.prepare()`
-
-Occasionally you may find you have an async boundary, where MDC is lost when a different Thread picks up the execution.
-If this is the case, you can call `prepare()` on the execution context while the MDC is available. e.g.
-
-```scala
-implicit val pec = ec.prepare()
-asyncBoundary // e.g. Akka flow
-  .map(next)// this will run next with `pec` which has had the MDC preserved
-```
-
-This should hopefully be rare since prepare is already called in many occasions. (Note, `prepare` is deprecated, but no alternative has been provided yet, and it continues to work.)
 
 ## Changes
 

--- a/bootstrap-backend-play-28/src/main/resources/backend.conf
+++ b/bootstrap-backend-play-28/src/main/resources/backend.conf
@@ -60,7 +60,7 @@ controllers {
 }
 
 akka.actor.default-dispatcher {
-  type = "uk.gov.hmrc.play.bootstrap.dispatchers.MdcPropagatingDispatcherConfigurator"
+  executor = "uk.gov.hmrc.play.bootstrap.dispatchers.MDCPropagatingExecutorServiceConfigurator"
 }
 
 play.ws.timeout.request = 20.seconds

--- a/bootstrap-common/src/main/scala/uk/gov/hmrc/play/bootstrap/dispatchers/MDCPropagatingExecutorService.scala
+++ b/bootstrap-common/src/main/scala/uk/gov/hmrc/play/bootstrap/dispatchers/MDCPropagatingExecutorService.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.bootstrap.dispatchers
+
+import java.util.concurrent.{ExecutorService, ThreadFactory}
+
+import akka.dispatch._
+import com.typesafe.config.Config
+import org.slf4j.MDC
+
+class MDCPropagatingExecutorServiceConfigurator(
+  config       : Config,
+  prerequisites: DispatcherPrerequisites
+) extends ExecutorServiceConfigurator(config, prerequisites) {
+
+  class MDCPropagatingExecutorServiceFactory(delegate: ExecutorServiceFactory) extends ExecutorServiceFactory {
+    override def createExecutorService: ExecutorService =
+      new MDCPropagatingExecutorService(delegate.createExecutorService)
+  }
+
+  override def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory = {
+
+    val factory = new ForkJoinExecutorConfigurator(config.getConfig("fork-join-executor"), prerequisites)
+      .createExecutorServiceFactory(id, threadFactory)
+
+    new MDCPropagatingExecutorServiceFactory(factory)
+  }
+}
+
+class MDCPropagatingExecutorService(val executor: ExecutorService) extends ExecutorServiceDelegate {
+
+  override def execute(command: Runnable): Unit = {
+    val mdcData = MDC.getCopyOfContextMap
+
+    executor.execute { () =>
+      val oldMdcData = MDC.getCopyOfContextMap
+      setMDC(mdcData)
+      try {
+        command.run()
+      } finally {
+        setMDC(oldMdcData)
+      }
+    }
+  }
+
+  private def setMDC(context: java.util.Map[String, String]): Unit =
+    if (context == null)
+      MDC.clear()
+    else
+      MDC.setContextMap(context)
+}

--- a/bootstrap-frontend-play-28/src/main/resources/frontend.conf
+++ b/bootstrap-frontend-play-28/src/main/resources/frontend.conf
@@ -97,7 +97,7 @@ controllers {
 caching.allowedContentTypes = ["image/", "text/css", "application/javascript"]
 
 akka.actor.default-dispatcher {
-  type = "uk.gov.hmrc.play.bootstrap.dispatchers.MdcPropagatingDispatcherConfigurator"
+  executor = "uk.gov.hmrc.play.bootstrap.dispatchers.MDCPropagatingExecutorServiceConfigurator"
 }
 
 play.ws.timeout.request = 20.seconds
@@ -126,7 +126,6 @@ play.filters.enabled  = [
   "uk.gov.hmrc.play.bootstrap.filters.AuditFilter",
   "uk.gov.hmrc.play.bootstrap.frontend.filters.SessionTimeoutFilter",
   "play.filters.csrf.CSRFFilter",
-  "uk.gov.hmrc.play.bootstrap.filters.MDCFilter", # CSRFFilter currently doesn't propagate MDC - so let's restore it
   "uk.gov.hmrc.play.bootstrap.filters.CacheControlFilter",
   "uk.gov.hmrc.play.bootstrap.frontend.filters.AllowlistFilter"
 ]


### PR DESCRIPTION
Using `MdcPropagatorExecutionContext` makes MDC propagate over promises etc implicitly. But unfortunately there are a few cases of `ExecutionContext#prepare()` not being called in play (most noticeably when `AkkaHttpServer` invokes the `HttpErrorHandler`) to make this a worthwhile improvement at the moment.