### PR TITLE
Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,12 +204,15 @@ bootstrap.filters.allowlist.redirectUrlWhenDenied = "http://www.gov.uk"
 
 ## Changes
 
+### Version 7.20.0
+- Updates playframework to 2.8.20
+
 ### Version 7.16.0
 - Updates the Allowlist Filter
   - removes all references to Akamai
   - provides a allowlist filter implementation and no longer extends the play-allowlist-filter library
   - new error handling and logging for configuration errors.
-  - updated config values 
+  - updated config values
     - `bootstrap.filters.allowlist.destination` is now obsolete use `bootstrap.filters.allowlist.redirectUrlWhenDenied` instead
     - `bootstrap.filters.allowlist.ips` is now an array
     - `bootstrap.filters.allowlist.excluded` is now an array

--- a/bootstrap-common/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AuthRedirects.scala
+++ b/bootstrap-common/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AuthRedirects.scala
@@ -31,7 +31,9 @@ trait AuthRedirects {
   def env: Environment
 
   private lazy val envPrefix =
-    if (env.mode.equals(Mode.Test)) "Test" else config.getOptional[String]("run.mode").getOrElse("Dev")
+    if (env.mode.equals(Mode.Test)) "Test"
+    else config.getOptional[String]("run.mode")
+           .getOrElse("Dev")
 
   private val hostDefaults: Map[String, String] = Map(
     "Dev.external-url.bas-gateway-frontend.host"           -> "http://localhost:9553",

--- a/bootstrap-frontend-play-28/src/main/resources/frontend.conf
+++ b/bootstrap-frontend-play-28/src/main/resources/frontend.conf
@@ -132,9 +132,6 @@ security.headers.filter.enabled = true
 bootstrap.filters.csrf.enabled = true
 bootstrap.filters.allowlist.enabled = false
 bootstrap.filters.allowlist.excluded = ["/ping/ping"]
-# the following need providing if enabled
-bootstrap.filters.allowlist.redirectUrlWhenDenied = null
-bootstrap.filters.allowlist.ips = null
 
 bootstrap.filters.sessionId.enabled = true
 

--- a/bootstrap-frontend-play-28/src/main/resources/reference.conf
+++ b/bootstrap-frontend-play-28/src/main/resources/reference.conf
@@ -16,3 +16,9 @@ bootstrap.auditfilter.maskedFormFields = []
 bootstrap.auditfilter.frontend.auditAllHeaders = false
 bootstrap.auditfilter.frontend.redactedHeaders = []
 bootstrap.auditfilter.frontend.redactedCookies = []
+
+bootstrap.filters.allowlist.enabled = false
+bootstrap.filters.allowlist.excluded = []
+# the following need providing if enabled
+bootstrap.filters.allowlist.redirectUrlWhenDenied = null
+bootstrap.filters.allowlist.ips = null

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object LibDependencies {
 
   private val play28Version          = "2.8.20"
-  private val httpVerbsVersion       = "14.9.0"
+  private val httpVerbsVersion       = "14.10.0"
   private val akkaVersion            = "2.6.21"
   private val jacksonVersion         = "2.12.6"
   private val jacksonDatabindVersion = "2.12.6.1"


### PR DESCRIPTION
Updates `http-verbs` for default config improvements.

Also moves default `bootstrap.filters.allowlist` into `reference.conf`.
`frontend.conf` is really for overriding configuration defined by libraries - so the initial default values should be in `reference.conf`. This is especially important for `null` (where in configuration analysis we often ignore values in reference.conf as uninteresting unless overridden)